### PR TITLE
Improve OvalBuilder Clone Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.arpnetworking.build</groupId>
     <artifactId>arpnetworking-parent-pom</artifactId>
-    <version>1.0.20</version>
+    <version>1.0.21</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Improved cloning performance by caching builder constructors for classes and by caching getter-setter pairs for classes.

Below are performance benchmarks on my macbook for a few different strategies cloning a simple bean-builder 1,000,000 each.

A) Original Reflection took: 3.203377442 sec
B) Original Reflection to Builder took: 1.695249988 sec
C) Cached Reflection took: 1.734845992 sec
D) Cached Reflection to Builder took: 0.058163933 sec
E) Jackson took: 1.167861154 sec

Above lines A and B represent the baseline performance of the current version first without specifying the builder instance and second when specifying it. Line C improves use case of A by caching the builder constructor for the input class. As the performance of C is now close to B (which differs from A where this work is done by the caller) this is nearly as good as it's going to get. 

Line D improves on use case B with a second caching of getter-setter pairs for each bean class. This bypasses builder/bean analysis entirely and is where most of the gains are to be had. This is nearly a 30x gain in performance over the current version!

Finally, for comparison we could delegate the entire operation to Jackson's ObjectMapper via its convertValue method. While this reduces the code to a single line inside a try-catch it's twice as slow as our cached reflection method. My best guess is that the looser (or more generic) type coupling plus independent method caches (as opposed to the GetterSetter pair we use) make up the bulk of the difference. Should we need more powerful mapping operation for clone this is probably where we should look in the future - but hopefully it does not come to that.