### PR TITLE
Fix Lack of Exception Wrapping in Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.arpnetworking.build</groupId>
     <artifactId>arpnetworking-parent-pom</artifactId>
-    <version>1.0.24</version>
+    <version>1.0.25</version>
     <relativePath />
   </parent>
 
@@ -29,7 +29,7 @@
   <name>Common Library</name>
   <description>Common utilities.</description>
   <url>https://github.com/ArpNetworking/commons</url>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
 
   <licenses>
     <license>

--- a/src/main/java/com/arpnetworking/commons/jackson/databind/ObjectMapperFactory.java
+++ b/src/main/java/com/arpnetworking/commons/jackson/databind/ObjectMapperFactory.java
@@ -85,7 +85,6 @@ public final class ObjectMapperFactory {
         registerModule(objectMapper, "com.fasterxml.jackson.datatype.jdk8.Jdk8Module");
         registerModule(objectMapper, "com.fasterxml.jackson.datatype.joda.JodaModule");
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        objectMapper.configure(DeserializationFeature.WRAP_EXCEPTIONS, false);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         objectMapper.setDateFormat(new ISO8601DateFormat());

--- a/src/test/java/com/arpnetworking/commons/jackson/databind/EnumerationDeserializerTest.java
+++ b/src/test/java/com/arpnetworking/commons/jackson/databind/EnumerationDeserializerTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import java.io.IOException;
 import java.util.Optional;
 
 /**
@@ -66,7 +67,8 @@ public class EnumerationDeserializerTest {
         try {
             final TestContainer c = objectMapper.readValue("{\"enum\":\"bar\"}", TestContainer.class);
             Assert.fail("Expected exception not thrown");
-        } catch (final EnumerationNotFoundException e) {
+        } catch (final IOException e) {
+            Assert.assertTrue(e.getCause() instanceof EnumerationNotFoundException);
             Mockito.verify(_strategy).toEnum(TestEnum.class, "bar");
             Mockito.verifyNoMoreInteractions(_strategy);
         }


### PR DESCRIPTION
Fixed bug in ObjectMapperFactory where exceptions (other than IOException derivatives) are not wrapped. This means some runtime exceptions may escape exception handling. The issue came to a head with Metrics Aggregator Daemon attaching data to parsing exceptions. Although all clients should already be catching IOException we are treating this bug fix as a Y-change.

__NOTE:__ Requires release of https://github.com/ArpNetworking/arpnetworking-parent-pom/pull/20/files

PS. I know you don't like this but I will be offline for a bit, and this will unblock you once you review and release the change above.