### PR TITLE
Duration Not as Timestamp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <jackson.version>2.7.4</jackson.version>
     <javassist.version>3.20.0-GA</javassist.version>
     <javassist.maven.core.version>0.1.2</javassist.maven.core.version>
+    <joda.time.version>2.4</joda.time.version>
     <jsr305.version>3.0.0</jsr305.version>
     <junit.version>4.12</junit.version>
     <logback.steno.version>1.15.0</logback.steno.version>
@@ -270,6 +271,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>${joda.time.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/arpnetworking/commons/jackson/databind/ObjectMapperFactory.java
+++ b/src/main/java/com/arpnetworking/commons/jackson/databind/ObjectMapperFactory.java
@@ -87,6 +87,7 @@ public final class ObjectMapperFactory {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        objectMapper.configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false);
         objectMapper.setDateFormat(new ISO8601DateFormat());
         return objectMapper;
     }

--- a/src/test/java/com/arpnetworking/commons/jackson/databind/ObjectMapperFactoryTest.java
+++ b/src/test/java/com/arpnetworking/commons/jackson/databind/ObjectMapperFactoryTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.joda.time.Duration;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -161,6 +162,13 @@ public class ObjectMapperFactoryTest {
         Assert.assertEquals("true", actualPresentValue);
         final String actualAbsentValue = objectMapper.writeValueAsString(com.google.common.base.Optional.absent());
         Assert.assertEquals("null", actualAbsentValue);
+    }
+
+    @Test
+    public void testDurationSerialization() throws JsonProcessingException {
+        final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+        final String actualPresentValue = objectMapper.writeValueAsString(Duration.standardSeconds(10));
+        Assert.assertEquals("\"PT10S\"", actualPresentValue);
     }
 
     /**


### PR DESCRIPTION
Alter duration serialization to not be as a timestamp; e.g. be instead in ISO-8601.