### PR TITLE
ThreadLocalSecureRandomUuidFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <oval.version>1.86</oval.version>
     <scala.version>2.11</scala.version>
     <scala.library.version>2.11.7</scala.library.version>
+    <system.rules.version>1.16.0</system.rules.version>
 
     <!-- Plugin versions -->
     <javassist.maven.plugin.version>0.1.3</javassist.maven.plugin.version>
@@ -271,6 +272,12 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <version>${jackson.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>${system.rules.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/arpnetworking/commons/uuidfactory/DefaultUuidFactory.java
+++ b/src/main/java/com/arpnetworking/commons/uuidfactory/DefaultUuidFactory.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016 Groupon.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.uuidfactory;
+
+import java.util.UUID;
+
+/**
+ * Generates a new {@code UUID} using Java's {@code java.util.UUID.randomUUID()}
+ * function.
+ *
+ * Dependencies:
+ * <ul>
+ *     <li><i>None</i></li>
+ * </ul>
+ *
+ * @author Matthew Hayter (mhayter at groupon dot com)
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public class DefaultUuidFactory implements UuidFactory {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UUID create() {
+        return UUID.randomUUID();
+    }
+}

--- a/src/main/java/com/arpnetworking/commons/uuidfactory/ThreadLocalSecureRandomUuidFactory.java
+++ b/src/main/java/com/arpnetworking/commons/uuidfactory/ThreadLocalSecureRandomUuidFactory.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016 Inscope Metrics Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.uuidfactory;
+
+import com.arpnetworking.steno.Logger;
+import com.arpnetworking.steno.LoggerFactory;
+
+import java.security.SecureRandom;
+import java.util.UUID;
+
+/**
+ * Generates a new {@code UUID} using thread local {@code SecureRandom}. Based
+ * heavily on implementation of the java-uuid-generator (JUG):
+ *
+ * https://github.com/cowtowncoder/java-uuid-generator
+ *
+ * And the implementation of {@code java.util.UUID}.
+ *
+ * Dependencies:
+ * <ul>
+ *     <li><i>None</i></li>
+ * </ul>
+ *
+ * Performance:
+ *
+ * 1) Default JVM arguments.
+ *
+ * DefaultUuidFactory: 338,516 tps
+ * ThreadLocalSecureRandomUuidFactory: 334,730 tps
+ *
+ * 2) Using urandom with:  {@code -Djava.security.egd=file:/dev/./urandom}
+ *
+ * DefaultUuidFactory: 1,312,707 tps
+ * ThreadLocalSecureRandomUuidFactory: 4,854,940
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public final class ThreadLocalSecureRandomUuidFactory implements UuidFactory {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UUID create() {
+        // As stated in JUG documentation the nextBytes call on SecureRandom is
+        // noticeably faster than calling nextLong twice. This was confirmed
+        // through adhoc performance testing.
+        final byte[] buffer = new byte[16];
+        SECURE_RANDOM_THREAD_LOCAL.get().nextBytes(buffer);
+        // The following is logic from java.util.UUID:
+        buffer[6]  &= 0x0f;  /* clear version        */
+        buffer[6]  |= 0x40;  /* set to version 4     */
+        buffer[8]  &= 0x3f;  /* clear variant        */
+        buffer[8]  |= 0x80;  /* set to IETF variant  */
+        final long msb = toLong(buffer, 0);
+        final long lsb = toLong(buffer, 1);
+        return new UUID(msb, lsb);
+    }
+
+    /* package private */ static long toLong(final byte[] buffer, final int offset) {
+        final long value1 = toInt(buffer, offset);
+        final long value2 = toInt(buffer, offset + 4);
+        return (value1 << 32) + ((value2 << 32) >>> 32);
+    }
+
+    /* package private */ static long toInt(final byte[] buffer, final int initialOffset) {
+        int offset = initialOffset;
+        return (buffer[offset] << 24)
+                + ((buffer[++offset] & 0xFF) << 16)
+                + ((buffer[++offset] & 0xFF) << 8)
+                + (buffer[++offset] & 0xFF);
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThreadLocalSecureRandomUuidFactory.class);
+
+    private static final ThreadLocal<SecureRandom> SECURE_RANDOM_THREAD_LOCAL = new ThreadLocal<SecureRandom>() {
+        @Override
+        protected SecureRandom initialValue() {
+            if (!URANDOM.equals(System.getProperty(KEY))) {
+                LOGGER.warn()
+                        .setMessage(
+                                String.format(
+                                        "Using ThreadLocalSecureRandomUuidFactory without -D%s=%s",
+                                        KEY,
+                                        URANDOM))
+                        .log();
+            }
+            final SecureRandom secureRandom = new SecureRandom();
+
+            // Force seeding; this may block until sufficient entropy exists
+            secureRandom.nextBytes(new byte[1]);
+
+            return secureRandom;
+        }
+
+        private static final String KEY = "java.security.egd";
+        private static final String URANDOM = "file:/dev/./urandom";
+    };
+}

--- a/src/main/java/com/arpnetworking/commons/uuidfactory/UuidFactory.java
+++ b/src/main/java/com/arpnetworking/commons/uuidfactory/UuidFactory.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 Groupon.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.uuidfactory;
+
+import java.util.UUID;
+
+/**
+ * Interface for classes that crate universally unique identifiers (UUIDs).
+ * This interface does not specify the manner or type of identifier that is
+ * created and implementations are not restricted to any particular method
+ * or type of identifier. However, implementations are expected to document
+ * the characteristics and method of generation in particular as it pertains
+ * to the uniquness of the identifier.
+ *
+ * Dependencies:
+ * <ul>
+ *     <li><i>None</i></li>
+ * </ul>
+ *
+ * @author Matthew Hayter (mhayter at groupon dot com)
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public interface UuidFactory {
+
+    /**
+     * Create a new {@code UUID}.
+     *
+     * @return A new {@code UUID}.
+     */
+    UUID create();
+}

--- a/src/test/java/com/arpnetworking/commons/uuidfactory/DefaultUuidFactoryTest.java
+++ b/src/test/java/com/arpnetworking/commons/uuidfactory/DefaultUuidFactoryTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Inscope Metrics Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.uuidfactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the DefaultUuidFactory class.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public class DefaultUuidFactoryTest {
+
+    @Test
+    public void test() {
+        final UuidFactory uuidFactory = new DefaultUuidFactory();
+        Assert.assertNotEquals(uuidFactory.create(), uuidFactory.create());
+    }
+}

--- a/src/test/java/com/arpnetworking/commons/uuidfactory/ThreadLocalSecureRandomUuidFactoryTest.java
+++ b/src/test/java/com/arpnetworking/commons/uuidfactory/ThreadLocalSecureRandomUuidFactoryTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2016 Inscope Metrics Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.uuidfactory;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TestRule;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for the DefaultUuidFactory class.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public class ThreadLocalSecureRandomUuidFactoryTest {
+
+    @Test
+    public void test() {
+        final UuidFactory uuidFactory = new ThreadLocalSecureRandomUuidFactory();
+        Assert.assertNotEquals(uuidFactory.create(), uuidFactory.create());
+    }
+
+    @Test
+    public void testWithURandom() throws InterruptedException {
+        // Run this test in a separate thread to ensure a new SecureRandom
+        // thread local is created.
+        System.setProperty("java.security.egd", "file:/dev/./urandom");
+        final UuidFactory uuidFactory = new ThreadLocalSecureRandomUuidFactory();
+        final ExecutorService executor = new ThreadPoolExecutor(
+                1,  // core threads
+                1,  // max threads
+                1,  // keep alive
+                TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(1));
+        executor.submit((Runnable) () -> Assert.assertNotEquals(uuidFactory.create(), uuidFactory.create()));
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testToLong() {
+        final ByteBuffer bytes = ByteBuffer.allocate(5 * 8);
+        bytes.putLong(Long.MIN_VALUE);
+        bytes.putLong(-1L);
+        bytes.putLong(0L);
+        bytes.putLong(1L);
+        bytes.putLong(Long.MAX_VALUE);
+
+        Assert.assertEquals(Long.MIN_VALUE, ThreadLocalSecureRandomUuidFactory.toLong(bytes.array(), 0));
+        Assert.assertEquals(-1L, ThreadLocalSecureRandomUuidFactory.toLong(bytes.array(), 8));
+        Assert.assertEquals(0L, ThreadLocalSecureRandomUuidFactory.toLong(bytes.array(), 16));
+        Assert.assertEquals(1L, ThreadLocalSecureRandomUuidFactory.toLong(bytes.array(), 24));
+        Assert.assertEquals(Long.MAX_VALUE, ThreadLocalSecureRandomUuidFactory.toLong(bytes.array(), 32));
+    }
+
+    @Test
+    public void testToInt() {
+        final ByteBuffer bytes = ByteBuffer.allocate(5 * 4);
+        bytes.putInt(Integer.MIN_VALUE);
+        bytes.putInt(-1);
+        bytes.putInt(0);
+        bytes.putInt(1);
+        bytes.putInt(Integer.MAX_VALUE);
+
+        Assert.assertEquals(Integer.MIN_VALUE, ThreadLocalSecureRandomUuidFactory.toInt(bytes.array(), 0));
+        Assert.assertEquals(-1, ThreadLocalSecureRandomUuidFactory.toInt(bytes.array(), 4));
+        Assert.assertEquals(0, ThreadLocalSecureRandomUuidFactory.toInt(bytes.array(), 8));
+        Assert.assertEquals(1, ThreadLocalSecureRandomUuidFactory.toInt(bytes.array(), 12));
+        Assert.assertEquals(Integer.MAX_VALUE, ThreadLocalSecureRandomUuidFactory.toInt(bytes.array(), 16));
+    }
+
+    @Rule
+    public final TestRule _restoreSystemProperties = new RestoreSystemProperties();
+}

--- a/src/test/java/com/arpnetworking/commons/uuidfactory/package-info.java
+++ b/src/test/java/com/arpnetworking/commons/uuidfactory/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2016 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ParametersAreNonnullByDefault
+package com.arpnetworking.commons.uuidfactory;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
Ported uuid factory interface from metrics-client-java with default java.util implementation. Added thread local SecureRandom implementation along with basic throughput comparison. Next step is to modify metrics-client-java to use this version and expose commons as a dependency.