### PR TITLE
Fix thread local builder pojo construction exception handling.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/ThreadLocalBuilderBasedDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/ThreadLocalBuilderBasedDeserializer.java
@@ -221,6 +221,10 @@ public class ThreadLocalBuilderBasedDeserializer extends BeanDeserializerBase {
                     });
         } catch (final WrappedIOExceptionException e) {
             throw e.getCause();
+            // CHECKSTYLE.OFF: IllegalCatch - Match behavior in BuilderBasedDeserializer
+        } catch (final Exception e) {
+            // CHECKSTYLE.ON: IllegalCatch
+            return _underlyingBuilderBasedDeserializer.wrapInstantiationProblem(e, ctxt);
         }
     }
 

--- a/src/test/java/com/arpnetworking/commons/builder/ThreadLocalBuilderTest.java
+++ b/src/test/java/com/arpnetworking/commons/builder/ThreadLocalBuilderTest.java
@@ -91,12 +91,20 @@ public final class ThreadLocalBuilderTest {
         Assert.assertEquals("bar", pojoB.getValue());
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testInvalidBuilder() {
-        InvalidThreadLocalPojo.Builder.build(
-                InvalidThreadLocalPojo.Builder.class,
+    @Test
+    public void testPrivatePojoBuilder() {
+        final PrivateThreadLocalPojo pojo = PrivateThreadLocalPojo.Builder.build(
+                PrivateThreadLocalPojo.Builder.class,
                 builder -> { });
-        Assert.fail("Builder construction should have failed");
+        Assert.assertNotNull(pojo);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testFailingPojoBuilder() {
+        ThrowingThreadLocalPojo.Builder.build(
+                ThrowingThreadLocalPojo.Builder.class,
+                builder -> { });
+        Assert.fail("Expected exception not thrown");
     }
 
     @Test
@@ -131,9 +139,6 @@ public final class ThreadLocalBuilderTest {
     }
 
     private static final class MyThreadLocalPojo {
-
-        // IMPORTANT: Because of the reset invocation counting you cannot use
-        // this builder class for any tests other than
 
         public String getValue() {
             return _value;
@@ -208,14 +213,30 @@ public final class ThreadLocalBuilderTest {
         }
     }
 
-    private static final class InvalidThreadLocalPojo {
+    private static final class PrivateThreadLocalPojo {
 
-        private InvalidThreadLocalPojo(final Builder builder) { }
+        private PrivateThreadLocalPojo(final Builder builder) { }
 
-        private static final class Builder extends ThreadLocalBuilder<InvalidThreadLocalPojo> {
+        private static final class Builder extends ThreadLocalBuilder<PrivateThreadLocalPojo> {
 
             private Builder() {
-                super(InvalidThreadLocalPojo::new);
+                super(PrivateThreadLocalPojo::new);
+            }
+
+            @Override
+            protected void reset() { }
+        }
+    }
+
+    private static final class ThrowingThreadLocalPojo {
+
+        private ThrowingThreadLocalPojo(final Builder builder) { }
+
+        private static final class Builder extends ThreadLocalBuilder<ThrowingThreadLocalPojo> {
+
+            private Builder() {
+                super(ThrowingThreadLocalPojo::new);
+                throw new NullPointerException("Builder construction exception");
             }
 
             @Override

--- a/src/test/java/com/arpnetworking/commons/jackson/databind/introspect/BuilderAnnotationIntrospectorTest.java
+++ b/src/test/java/com/arpnetworking/commons/jackson/databind/introspect/BuilderAnnotationIntrospectorTest.java
@@ -15,10 +15,12 @@
  */
 package com.arpnetworking.commons.jackson.databind.introspect;
 
+import com.arpnetworking.commons.builder.OvalBuilder;
 import com.arpnetworking.commons.builder.ThreadLocalBuilder;
 import com.arpnetworking.commons.jackson.databind.ObjectMapperFactory;
 import com.arpnetworking.commons.jackson.databind.annotation.JsonIgnoreBuilder;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
@@ -187,6 +189,12 @@ public class BuilderAnnotationIntrospectorTest {
         Assert.assertNotNull(pojo);
         Assert.assertEquals("foo", pojo.getStrVal());
         Assert.assertEquals(countBefore, countAfter);
+    }
+
+    @Test(expected = JsonProcessingException.class)
+    public void testPojoConstructionFailure() throws IOException {
+        OBJECT_MAPPER.readValue("{}", MyThrowingThreadLocalPojo.class);
+        Assert.fail("build should have thrown");
     }
 
     private BuilderAnnotationIntrospector _introspector;
@@ -385,6 +393,20 @@ public class BuilderAnnotationIntrospectorTest {
             private Integer _integerValue;
             private String _strVal;
             private String _source = "builder";
+        }
+    }
+
+    private static final class MyThrowingThreadLocalPojo {
+
+        private MyThrowingThreadLocalPojo(final MyThrowingThreadLocalPojo.Builder builder) {
+            throw new NullPointerException("Construction failure");
+        }
+
+        private static final class Builder extends OvalBuilder<MyThrowingThreadLocalPojo> {
+
+            /* package private */ Builder() {
+                super(MyThrowingThreadLocalPojo::new);
+            }
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/databind/deser/ThreadLocalBuilderBasedDeserializerTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/deser/ThreadLocalBuilderBasedDeserializerTest.java
@@ -18,6 +18,7 @@ package com.fasterxml.jackson.databind.deser;
 import com.arpnetworking.commons.builder.ThreadLocalBuilder;
 import com.arpnetworking.commons.jackson.databind.ObjectMapperFactory;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -103,6 +104,12 @@ public final class ThreadLocalBuilderBasedDeserializerTest {
         }
     }
 
+    @Test(expected = JsonProcessingException.class)
+    public void testConstructionFailure() throws IOException {
+        OBJECT_MAPPER.readValue("{}", MyThrowingThreadLocalPojo.class);
+        Assert.fail("build should have thrown");
+    }
+
     private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 
     private static final class TestBeanWithCreator {
@@ -184,6 +191,25 @@ public final class ThreadLocalBuilderBasedDeserializerTest {
 
             @NotNull
             private Integer _i;
+        }
+    }
+
+    private static final class MyThrowingThreadLocalPojo {
+
+        private MyThrowingThreadLocalPojo(final Builder builder) {
+            throw new NullPointerException("Construction failure");
+        }
+
+        private static final class Builder extends ThreadLocalBuilder<MyThrowingThreadLocalPojo> {
+
+            /* package private */ Builder() {
+                super(MyThrowingThreadLocalPojo::new);
+            }
+
+            @Override
+            protected void reset() {
+                // Nothing to do
+            }
         }
     }
 }


### PR DESCRIPTION
Fix thread local builder pojo construction exception handling to match the implementation in the Jackson provided builder based deserializer. Also allows thread local builder instances to be private.