### PR TITLE
CompletableFutures.allOf(List<CompletableFuture<?>>)

### DIFF
--- a/src/main/java/com/arpnetworking/commons/builder/ThreadLocalBuilder.java
+++ b/src/main/java/com/arpnetworking/commons/builder/ThreadLocalBuilder.java
@@ -48,6 +48,12 @@ import javax.annotation.Nullable;
  *
  * All concrete subclasses must implement a public no-args constructor.
  *
+ * Dependencies:
+ * <ul>
+ *     <li>net.sf.oval:oval</li>
+ *     <li>com.google.guava:guava</li>
+ * </ul>
+ *
  * @param <T> The type of object created by the builder.
  *
  * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)

--- a/src/main/java/com/arpnetworking/commons/java/util/concurrent/CompletableFutures.java
+++ b/src/main/java/com/arpnetworking/commons/java/util/concurrent/CompletableFutures.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.java.util.concurrent;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Helper methods for Java's CompletableFuture.
+ *
+ * Dependencies:
+ * <i>None</i>
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public final class CompletableFutures {
+
+    /**
+     * Variant of {@code CompletableFuture.allOf(CompletableFuture<?>...)}
+     * that accepts a list of {@code CompletableFuture<T>} instead of an array.
+     * Encapsulates the array creation and associated unsafe casting and raw
+     * types warnings.
+     *
+     * @param futures the CompletableFutures
+     * @return a new CompletableFuture that is completed when all of the
+     * given CompletableFutures complete
+     */
+    public static CompletableFuture<?> allOf(final Collection<?> futures) {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        final CompletableFuture[] futuresArray = futures.toArray(new CompletableFuture[0]);
+        return CompletableFuture.allOf(futuresArray);
+    }
+
+    private CompletableFutures() {}
+}

--- a/src/main/java/com/arpnetworking/commons/java/util/concurrent/package-info.java
+++ b/src/main/java/com/arpnetworking/commons/java/util/concurrent/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.arpnetworking.commons.java.util.concurrent;
+
+import com.arpnetworking.commons.javax.annotation.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/arpnetworking/commons/java/util/function/SingletonSupplier.java
+++ b/src/main/java/com/arpnetworking/commons/java/util/function/SingletonSupplier.java
@@ -28,6 +28,9 @@ import java.util.function.Supplier;
  * it does guarantee that ony a single instance is returned from this
  * {@code Supplier} for the life of the application.
  *
+ * Dependencies:
+ * <i>None</i>
+ *
  * @param <T> the type of object supplied by this {@code Supplier}
  *
  * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)

--- a/src/test/java/com/arpnetworking/commons/java/util/concurrent/CompletableFuturesTest.java
+++ b/src/test/java/com/arpnetworking/commons/java/util/concurrent/CompletableFuturesTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.java.util.concurrent;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Tests for the CompletableFutures class.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public final class CompletableFuturesTest {
+
+    @Test
+    public void testEmpty() throws ExecutionException, InterruptedException {
+        final List<CompletableFuture<?>> futures = new ArrayList<>();
+        final CompletableFuture<?> allFuture = CompletableFutures.allOf(futures);
+        Assert.assertNull(allFuture.get());
+        Assert.assertFalse(allFuture.isCompletedExceptionally());
+    }
+
+    @Test
+    public void testSuccess() throws ExecutionException, InterruptedException {
+        final List<CompletableFuture<?>> futures = new ArrayList<>();
+        futures.add(completed("foo"));
+        futures.add(completed("bar"));
+        final CompletableFuture<?> allFuture = CompletableFutures.allOf(futures);
+        Assert.assertNull(allFuture.get());
+        Assert.assertFalse(allFuture.isCompletedExceptionally());
+    }
+
+    @Test
+    public void testFailure() throws InterruptedException {
+        final List<CompletableFuture<?>> futures = new ArrayList<>();
+        futures.add(failed("foo"));
+        futures.add(failed("bar"));
+        final CompletableFuture<?> allFuture = CompletableFutures.allOf(futures);
+        Assert.assertTrue(allFuture.isCompletedExceptionally());
+        try {
+            allFuture.get();
+            Assert.fail("Expected exception not thrown");
+        } catch (final ExecutionException e) {
+            final Throwable cause = e.getCause();
+            Assert.assertTrue(cause.getMessage().equals("foo") || cause.getMessage().equals("bar"));
+        }
+    }
+
+    @Test
+    public void testMixed() throws InterruptedException {
+        final List<CompletableFuture<?>> futures = new ArrayList<>();
+        futures.add(completed("foo"));
+        futures.add(failed("bar"));
+        final CompletableFuture<?> allFuture = CompletableFutures.allOf(futures);
+        Assert.assertTrue(allFuture.isCompletedExceptionally());
+        try {
+            allFuture.get();
+            Assert.fail("Expected exception not thrown");
+        } catch (final ExecutionException e) {
+            Assert.assertTrue(e.getCause().getMessage().equals("bar"));
+        }
+    }
+
+    private static CompletableFuture<String> completed(final String s) {
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        future.complete(s);
+        return future;
+    }
+
+    private static CompletableFuture<String> failed(final String s) {
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        future.completeExceptionally(new Exception(s));
+        return future;
+    }
+}

--- a/src/test/java/com/arpnetworking/commons/java/util/concurrent/package-info.java
+++ b/src/test/java/com/arpnetworking/commons/java/util/concurrent/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.arpnetworking.commons.java.util.concurrent;
+
+import com.arpnetworking.commons.javax.annotation.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
Add helper class CompletableFutures with allOf method accepting a list of CompletableFutures encapsulating the array creation, casting and rawtypes that are required to use the Java8 CompletableFuture.allOf method accepting an array.