### PR TITLE
Add test helper for ThreadLocalBuilder reset method.

### DIFF
--- a/jdk-wrapper.sh
+++ b/jdk-wrapper.sh
@@ -43,10 +43,12 @@ safe_command() {
 checksum() {
   l_file="$1"
   checksum_exec=""
+  checksum_args=""
   if command -v sha256sum > /dev/null; then
     checksum_exec="sha256sum"
   elif command -v shasum > /dev/null; then
-    checksum_exec="shasum -a 256"
+    checksum_exec="shasum"
+    checksum_args="-a 256"
   elif command -v sha1sum > /dev/null; then
     checksum_exec="sha1sum"
   elif command -v md5 > /dev/null; then
@@ -56,7 +58,7 @@ checksum() {
     log_err "ERROR: No supported checksum command found!"
     exit 1
   fi
-  "${checksum_exec}" < "${l_file}"
+  ${checksum_exec} ${checksum_args} < "${l_file}"
 }
 
 rand() {
@@ -175,28 +177,6 @@ jdkw_wrapper="jdk-wrapper.sh"
 download_if_needed "${jdkw_impl}" "${jdkw_path}"
 download_if_needed "${jdkw_wrapper}" "${jdkw_path}"
 
-# Execute the provided command
-
-# Run the command in the backround (with all the trouble that entails)
-# NOTE: Alternatively convert this to an exec if we don't need to output the
-# wrapper mismatch at the end; e.g. make that a hard precondition to running.
-set -m
-trap 'kill -TERM ${impl_pid}' TERM INT
-"${jdkw_path}/${jdkw_impl}" "$@" &
-impl_pid=$!
-fg
-wait ${impl_pid} > /dev/null 2>&1
-wait_result=$?
-if [ ${wait_result} -ne 127 ]; then
-  result=${wait_result}
-fi
-trap - TERM INT
-wait ${impl_pid} > /dev/null 2>&1
-wait_result=$?
-if [ ${wait_result} -ne 127 ]; then
-  result=${wait_result}
-fi
-
 # Check whether this wrapper is the one specified for this version
 jdkw_download="${jdkw_path}/${jdkw_wrapper}"
 jdkw_current="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/$(basename "$0")"
@@ -204,6 +184,13 @@ if [ "$(checksum "${jdkw_download}")" != "$(checksum "${jdkw_current}")" ]; then
   printf "\e[0;31m[WARNING]\e[0m Your jdk-wrapper.sh file does not match the one in your JDKW_RELEASE.\n"
   printf "\e[0;32mUpdate your jdk-wrapper.sh to match by running:\e[0m\n"
   printf "cp \"%s\" \"%s\"\n" "${jdkw_download}" "${jdkw_current}"
+  sleep 3
 fi
 
-exit ${result}
+# Execute the provided command
+# NOTE: The requirements proved quite difficult to run this without exec.
+# 1) Exit with the exit status of the child process
+# 2) Allow running the wrapper in the background and terminating the child process
+# 3) Allow the child process to read from standard input when not running in the background
+exec "${jdkw_path}/${jdkw_impl}" "$@"
+

--- a/src/main/java/com/arpnetworking/commons/test/BuilderTestUtility.java
+++ b/src/main/java/com/arpnetworking/commons/test/BuilderTestUtility.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.test;
+
+import com.arpnetworking.commons.builder.Builder;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Shared methods for {@link com.arpnetworking.commons.builder.Builder} test
+ * helpers.
+ *
+ * @author Ville Koskela (ville at koskilabs dot com)
+ */
+public final class BuilderTestUtility {
+
+    static List<Method> getSetters(final Class<? extends Builder<?>> builderClass) {
+        final List<Method> setters = new ArrayList<>();
+        for (final Method method : builderClass.getMethods()) {
+            if (method.getName().startsWith(SETTER_PREFIX)
+                    && Builder.class.isAssignableFrom(method.getReturnType())
+                    && method.getParameters().length == 1
+                    && !method.isVarArgs()) {
+                setters.add(method);
+            }
+        }
+        return setters;
+    }
+
+    static <T> Optional<Field> getField(final Class<T> targetClass, final Method setter) {
+        final String fieldName =
+                "_" + Character.toLowerCase(setter.getName().charAt(SETTER_PREFIX.length()))
+                        + setter.getName().substring(SETTER_PREFIX.length() + 1);
+        try {
+            return Optional.of(targetClass.getDeclaredField(fieldName));
+        } catch (final NoSuchFieldException e) {
+            return Optional.empty();
+        }
+    }
+
+    static <T> Object getFieldValue(final T target, final Field field) throws IllegalAccessException {
+        AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+            field.setAccessible(true);
+            return null;
+        });
+        return field.get(target);
+    }
+
+    static <T> Optional<Method> getterForSetter(final Class<T> targetClass, final Method setter) {
+        final String getterName = GETTER_PREFIX + setter.getName().substring(SETTER_PREFIX.length());
+        try {
+            return Optional.of(targetClass.getDeclaredMethod(getterName));
+        } catch (final NoSuchMethodException e) {
+            return Optional.empty();
+        }
+    }
+
+    private BuilderTestUtility() {}
+
+    static final String SETTER_PREFIX = "set";
+    static final String GETTER_PREFIX = "get";
+}

--- a/src/main/java/com/arpnetworking/commons/test/ThreadLocalBuildableTestHelper.java
+++ b/src/main/java/com/arpnetworking/commons/test/ThreadLocalBuildableTestHelper.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.test;
+
+import com.arpnetworking.commons.builder.Builder;
+import com.arpnetworking.commons.builder.ThreadLocalBuilder;
+import com.google.common.collect.Maps;
+import org.junit.Assert;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Test utility for {@link ThreadLocalBuilder} created instances to validate
+ * that all fields are set to the same initial values as after construction
+ * when {@code ThreadLocalBuilder.reset()} is called. This is most suitable for
+ * testing POJOs where all fields set on the {@link Builder} are typically
+ * copied and available on the instance.
+ *
+ * Dependencies:
+ * <ul>
+ *     <li>junit:junit</li>
+ * </ul>
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public final class ThreadLocalBuildableTestHelper {
+
+    /**
+     * Test that fields set via {@code builder} setters are set to same initial
+     * values as after construction when {@code ThreadLocalBuilder.reset()} is
+     * called.
+     *
+     * <b>IMPORTANT:</b> This test is destructive on the provided builder!
+     *
+     * @param builder the builder instance to test with non-default values set
+     * for all fields
+     * @param <T> the type built by the specified builder
+     * @throws InvocationTargetException if a setter or getter call throws an exception
+     * @throws IllegalAccessException if a setter or getter is inaccessible
+     * @throws InstantiationException if a new instance of {@code builder} cannot be created
+     * @throws NoSuchMethodException if {@link ThreadLocalBuilder} no longer has a {@code reset()} method
+     */
+    // CHECKSTYLE.OFF: ThrowsCount - NoSuchMethodException must be thrown as conversion is untestable
+    public static <T> void testReset(final ThreadLocalBuilder<? extends T> builder)
+            throws InvocationTargetException, IllegalAccessException, InstantiationException, NoSuchMethodException {
+        // CHECKSTYLE.ON: ThrowsCount
+        @SuppressWarnings("unchecked")
+        final Class<? extends ThreadLocalBuilder<T>> builderClass = (Class<? extends ThreadLocalBuilder<T>>) builder.getClass();
+        final Map<Field, Object> expectedValues = Maps.newHashMap();
+
+        // Capture the builder state
+        for (final Method method : BuilderTestUtility.getSetters(builderClass)) {
+            final Optional<Field> field = BuilderTestUtility.getField(builderClass, method);
+            if (!field.isPresent()) {
+                throw new IllegalStateException("Builder setter does not have matching field");
+            }
+            final Object expectedValue = BuilderTestUtility.getFieldValue(builder, field.get());
+            Assert.assertNotNull("Expected value can not be null", expectedValue);
+            expectedValues.put(field.get(), expectedValue);
+        }
+
+        // Create a new builder for comparison
+        final ThreadLocalBuilder<? extends T> newBuilder = builderClass.newInstance();
+
+        // Reset the provided builder for comparison
+        // NOTE: This is destructive on the state of the provided builder!
+        final Method resetMethod = ThreadLocalBuilder.class.getDeclaredMethod("reset");
+        resetMethod.setAccessible(true);
+        resetMethod.invoke(builder);
+
+        // Compare the builder states
+        // 1) The reset state should differ from the provided state (precondition)
+        // 2) The new state should differ from the provided state (precondition)
+        // 3) The reset state should be the _same_ as the new state
+        // ^ A new default value should NOT be created for each instance
+        for (final Map.Entry<Field, Object> entry : expectedValues.entrySet()) {
+            final Field field = entry.getKey();
+            final Object providedValue = entry.getValue();
+            final Object newBuilderValue = BuilderTestUtility.getFieldValue(newBuilder, field);
+            final Object resetBuilderValue = BuilderTestUtility.getFieldValue(builder, field);
+
+            Assert.assertNotEquals(
+                    String.format(
+                            "Field %s on provided builder is same as constructed value",
+                            field.getName()),
+                    providedValue,
+                    newBuilderValue);
+            Assert.assertNotEquals(
+                    String.format(
+                            "Field %s on provided builder is same as reset value",
+                            field.getName()),
+                    providedValue,
+                    resetBuilderValue);
+            Assert.assertSame(
+                    String.format(
+                            "Field %s is not the same on reset and construction",
+                            field.getName()),
+                    newBuilderValue,
+                    resetBuilderValue);
+        }
+    }
+
+    private ThreadLocalBuildableTestHelper() {}
+}

--- a/src/test/java/com/arpnetworking/commons/test/ThreadLocalBuildableTestHelperTest.java
+++ b/src/test/java/com/arpnetworking/commons/test/ThreadLocalBuildableTestHelperTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2018 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.test;
+
+import com.arpnetworking.commons.builder.ThreadLocalBuilder;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link BuildableTestHelper} class.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public final class ThreadLocalBuildableTestHelperTest {
+
+    @Test
+    public void testWorkingReset() throws Exception {
+        ThreadLocalBuildableTestHelper.testReset(
+                new PojoWorkingBuilder.Builder()
+                        .setValue("foo"));
+    }
+
+    @Test
+    public void testWorkingNonNullDefaultReset() throws Exception  {
+        ThreadLocalBuildableTestHelper.testReset(
+                new PojoWorkingBuilder.Builder()
+                        .setValue("foo"));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testBrokenBuilder() throws Exception  {
+        ThreadLocalBuildableTestHelper.testReset(
+                new PojoBrokenBuilder.Builder()
+                        .setValue("foo"));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testMissingFieldBuilder() throws Exception  {
+        ThreadLocalBuildableTestHelper.testReset(
+                new PojoMissingFieldBuilder.Builder()
+                        .setValue("foo"));
+    }
+
+    private static final class PojoWorkingBuilder {
+
+        public String getValue() {
+            return _value;
+        }
+
+        private PojoWorkingBuilder(final PojoWorkingBuilder.Builder builder) {
+            _value = builder._value;
+        }
+
+        private final String _value;
+
+        private static final class Builder extends ThreadLocalBuilder<PojoWorkingBuilder> {
+
+            protected Builder() {
+                super(ThreadLocalBuildableTestHelperTest.PojoWorkingBuilder::new);
+            }
+
+            public Builder setValue(final String value) {
+                _value = value;
+                return this;
+            }
+
+            @Override
+            protected void reset() {
+                _value = null;
+            }
+
+            private String _value;
+        }
+    }
+
+    private static final class PojoBrokenBuilder {
+
+        public String getValue() {
+            return _value;
+        }
+
+        private PojoBrokenBuilder(final Builder builder) {
+            _value = builder._value;
+        }
+
+        private final String _value;
+
+        private static final class Builder extends ThreadLocalBuilder<PojoBrokenBuilder> {
+
+            protected Builder() {
+                super(ThreadLocalBuildableTestHelperTest.PojoBrokenBuilder::new);
+            }
+
+            public Builder setValue(final String value) {
+                _value = value;
+                return this;
+            }
+
+            @Override
+            protected void reset() {
+                // Intentionally broken reset implementation
+            }
+
+            private String _value;
+        }
+    }
+
+    private static final class PojoNonNullDefaultBuilder {
+
+        public String getValue() {
+            return _value;
+        }
+
+        private PojoNonNullDefaultBuilder(final PojoNonNullDefaultBuilder.Builder builder) {
+            _value = builder._value;
+        }
+
+        private final String _value;
+
+        private static final class Builder extends ThreadLocalBuilder<PojoNonNullDefaultBuilder> {
+
+            protected Builder() {
+                super(ThreadLocalBuildableTestHelperTest.PojoNonNullDefaultBuilder::new);
+            }
+
+            public Builder setValue(final String value) {
+                _value = value;
+                return this;
+            }
+
+            @Override
+            protected void reset() {
+                _value = "bar";
+            }
+
+            private String _value = "bar";
+        }
+    }
+
+    private static final class PojoMissingFieldBuilder {
+
+        public String getValue() {
+            return _value;
+        }
+
+        private PojoMissingFieldBuilder(final PojoMissingFieldBuilder.Builder builder) {
+            _value = builder._fooValue;
+        }
+
+        private final String _value;
+
+        private static final class Builder extends ThreadLocalBuilder<PojoMissingFieldBuilder> {
+
+            protected Builder() {
+                super(ThreadLocalBuildableTestHelperTest.PojoMissingFieldBuilder::new);
+            }
+
+            public Builder setValue(final String value) {
+                // The field name must be derived from the setter name!
+                _fooValue = value;
+                return this;
+            }
+
+            @Override
+            protected void reset() {
+                _fooValue = null;
+            }
+
+            private String _fooValue;
+        }
+    }
+}


### PR DESCRIPTION
The test using the new `ThreadLocalBuildableTestHelper.testRest` along with `BuilderTestHelkper.testBuild` looks like this:

```
    private final Supplier<DefaultRecord.Builder> _defaultRecordBuilder = () -> new DefaultRecord.Builder()
            .setTime(ZonedDateTime.now())
            .setId(UUID.randomUUID().toString())
            .setDimensions(ImmutableMap.of("dKey", "dValue"))
            .setAnnotations(ImmutableMap.of("aKey", "aValue"))
            .setMetrics(ImmutableMap.of(
                    "metric",
                    TestBeanFactory.createMetric()));

    @Test
    public void testBuilder() throws InvocationTargetException, IllegalAccessException {
        BuildableTestHelper.testBuild(
                _defaultRecordBuilder.get(),
                Record.class);
    }

    @Test
    public void testReset() throws Exception {
        ThreadLocalBuildableTestHelper.testReset(_defaultRecordBuilder.get());
    }
```

^ Taken from MAD where I was testing this pattern out.