### PR TITLE
Implementation of double summation algorithms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,19 @@ You may also need to add the local repository to your build in order to pick-up 
 * Gradle - Add *mavenLocal()* to *build.gradle* in the *repositories* block.
 * SBT - Add *resolvers += Resolver.mavenLocal* into *project/plugins.sbt*.
 
+Performance Test
+----------------
+
+Running:
+
+    commons> ./jdk-wrapper.sh ./mvnw test -PunitPerformanceTest
+
+Results:
+
+* JSON formatted performance results are generated into `target/perf` as specified in each test's `JsonBenchmarkConsumer`.
+* Each JSON performance result file references an [HPROF](https://docs.oracle.com/javase/8/docs/technotes/samples/hprof.html) cpu profile generated during the test in `profileFile` field.
+* The performance profiles are text files and have been prefiltered using [performance-test](https://github.com/ArpNetworking/performance-test).
+
 License
 -------
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,11 @@
     <javax.inject.version>1</javax.inject.version>
     <jsr305.version>3.0.2</jsr305.version>
     <junit.version>4.13</junit.version>
+    <junit.benchmarks.version>0.7.2</junit.benchmarks.version>
+    <logback.version>1.2.3</logback.version>
     <mockito.version>2.23.4</mockito.version>
     <oval.version>1.90</oval.version>
+    <performance.test.version>1.2.1</performance.test.version>
     <scala.version>2.13</scala.version>
     <scala.library.version>2.13.2</scala.library.version>
     <slf4j.version>1.7.30</slf4j.version>
@@ -325,5 +328,68 @@
       <version>${system.rules.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- Test - Performance -->
+    <dependency>
+      <groupId>com.carrotsearch</groupId>
+      <artifactId>junit-benchmarks</artifactId>
+      <version>${junit.benchmarks.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.arpnetworking.test</groupId>
+      <artifactId>performance-test</artifactId>
+      <version>${performance.test.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.arpnetworking.commons</groupId>
+          <artifactId>commons</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>${logback.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>unitPerformanceTest</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-test</id>
+                <configuration>
+                  <includes>
+                    <include>**/*TestPerf.java</include>
+                  </includes>
+                  <parallel combine.self="override" />
+                  <forkMode>always</forkMode>
+                  <forkCount>1</forkCount>
+                  <reuseForks>false</reuseForks>
+                  <argLine combine.self="override">-agentlib:hprof=cpu=samples,depth=20,interval=10,force=y,verbose=y,doe=n,file=${project.build.directory}/perf.unit.hprof.txt -Dlogback.configurationFile="logback-perf.xml"</argLine>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/main/java/com/arpnetworking/commons/math/Accumulator.java
+++ b/src/main/java/com/arpnetworking/commons/math/Accumulator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.commons.math;
+
+/**
+ * Interface for summing doubles.
+ *
+ * Dependencies:
+ * <ul>
+ *     <li><i>None</i></li>
+ * </ul>
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public interface Accumulator {
+
+    /**
+     * Add a double value to the running sum.
+     *
+     * @param value the value to add
+     */
+    void accumulate(double value);
+
+    /**
+     * Retrieve the sum so far.
+     *
+     * @return the sum
+     */
+    double getSum();
+}

--- a/src/main/java/com/arpnetworking/commons/math/BigDecimalAccumulator.java
+++ b/src/main/java/com/arpnetworking/commons/math/BigDecimalAccumulator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.commons.math;
+
+import java.math.BigDecimal;
+
+/**
+ * Accumulator implementation using {@link BigDecimal}. This has no error.
+ * Although the precision of the result is still subject to constraints of
+ * representation as a {@code double}.
+ *
+ * Dependencies:
+ * <ul>
+ *     <li><i>None</i></li>
+ * </ul>
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public final class BigDecimalAccumulator implements Accumulator {
+
+    private BigDecimal _sum = new BigDecimal(0.0);
+
+    @Override
+    public void accumulate(final double value) {
+        _sum = _sum.add(new BigDecimal(value));
+    }
+
+    @Override
+    public double getSum() {
+        return _sum.doubleValue();
+    }
+}

--- a/src/main/java/com/arpnetworking/commons/math/KahanAccumulator.java
+++ b/src/main/java/com/arpnetworking/commons/math/KahanAccumulator.java
@@ -17,7 +17,8 @@
 package com.arpnetworking.commons.math;
 
 /**
- * Accumulator implementation using Kahan Sum algorithm. This has O(1) error.
+ * Accumulator implementation using Kahan Sum algorithm. This has effectively
+ * O(1) error.
  *
  * https://en.wikipedia.org/wiki/Kahan_summation_algorithm
  *

--- a/src/main/java/com/arpnetworking/commons/math/KahanAccumulator.java
+++ b/src/main/java/com/arpnetworking/commons/math/KahanAccumulator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.commons.math;
+
+/**
+ * Accumulator implementation using Kahan Sum algorithm. This has O(1) error.
+ *
+ * https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+ *
+ * Dependencies:
+ * <ul>
+ *     <li><i>None</i></li>
+ * </ul>
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public final class KahanAccumulator implements Accumulator {
+
+    private double _sum = 0.0;
+    private double _compensation = 0.0;
+
+    @Override
+    public void accumulate(final double value) {
+        final double delta = value - _compensation;
+        final double total = _sum + delta;
+        _compensation = (total - _sum) - delta;
+        _sum = total;
+    }
+
+    @Override
+    public double getSum() {
+        return _sum;
+    }
+}

--- a/src/main/java/com/arpnetworking/commons/math/NaiveAccumulator.java
+++ b/src/main/java/com/arpnetworking/commons/math/NaiveAccumulator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.commons.math;
+
+/**
+ * Naive accumulator implementation. Adds values together as they are presented.
+ * This has unbound error.
+ *
+ * Dependencies:
+ * <ul>
+ *     <li><i>None</i></li>
+ * </ul>
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public final class NaiveAccumulator implements Accumulator {
+
+    private double _sum;
+
+    @Override
+    public void accumulate(final double value) {
+        _sum += value;
+    }
+
+    @Override
+    public double getSum() {
+        return _sum;
+    }
+}

--- a/src/main/java/com/arpnetworking/commons/math/NeumaierAccumulator.java
+++ b/src/main/java/com/arpnetworking/commons/math/NeumaierAccumulator.java
@@ -18,7 +18,7 @@ package com.arpnetworking.commons.math;
 
 /**
  * Accumulator implementation using Neumaier version of the Kahan Sum algorithm.
- * This has O(1) error.
+ * This has effectively O(1) error.
  *
  * https://en.wikipedia.org/wiki/Kahan_summation_algorithm
  *

--- a/src/main/java/com/arpnetworking/commons/math/NeumaierAccumulator.java
+++ b/src/main/java/com/arpnetworking/commons/math/NeumaierAccumulator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.commons.math;
+
+/**
+ * Accumulator implementation using Neumaier version of the Kahan Sum algorithm.
+ * This has O(1) error.
+ *
+ * https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+ *
+ * Dependencies:
+ * <ul>
+ *     <li><i>None</i></li>
+ * </ul>
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public final class NeumaierAccumulator implements Accumulator {
+
+    private double _sum = 0.0;
+    private double _compensation = 0.0;
+
+    @Override
+    public void accumulate(final double value) {
+        final double total = _sum + value;
+        if (Math.abs(_sum) >= Math.abs(value)) {
+            _compensation += (_sum - total) + value;
+        } else {
+            _compensation += (value - total) + _sum;
+        }
+        _sum = total;
+    }
+
+    @Override
+    public double getSum() {
+        return _sum + _compensation;
+    }
+}

--- a/src/main/java/com/arpnetworking/commons/math/PairwiseAccumulator.java
+++ b/src/main/java/com/arpnetworking/commons/math/PairwiseAccumulator.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Accumulator implementation using Kahan Sum algorithm. This has O(log N) error.
+ * Accumulator implementation using pair-wise sum algorithm. This has O(log N) error.
  *
  * https://en.wikipedia.org/wiki/Pairwise_summation
  *

--- a/src/main/java/com/arpnetworking/commons/math/PairwiseAccumulator.java
+++ b/src/main/java/com/arpnetworking/commons/math/PairwiseAccumulator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.commons.math;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Accumulator implementation using Kahan Sum algorithm. This has O(log N) error.
+ *
+ * https://en.wikipedia.org/wiki/Pairwise_summation
+ *
+ * <b>WARNING</b>: Unlike the other implementations of {@link Accumulator} this
+ * implementation must buffer the samples. Consider your memory constraints
+ * before using.
+ *
+ * Dependencies:
+ * <ul>
+ *     <li><i>None</i></li>
+ * </ul>
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public final class PairwiseAccumulator implements Accumulator {
+
+    private static final int INITIAL_SIZE = 64;
+    private static final int BASE = 4;
+
+    private List<Double> _buffer = new ArrayList<>(INITIAL_SIZE);
+
+    @Override
+    public void accumulate(final double value) {
+        _buffer.add(value);
+    }
+
+    @Override
+    public double getSum() {
+        return recursiveSum(_buffer);
+    }
+
+    private static double recursiveSum(final List<Double> values) {
+        final int range = values.size();
+
+        // Base case
+        if (range <= BASE) {
+            double partialSum = 0.0;
+            for (final double value : values) {
+                partialSum += value;
+            }
+            return partialSum;
+        }
+
+        // Recursive split the array
+        final int splitIndex = (int) Math.floor(range / 2.0);
+        return recursiveSum(values.subList(0, splitIndex))
+                + recursiveSum(values.subList(splitIndex, range));
+    }
+}

--- a/src/main/java/com/arpnetworking/commons/math/package-info.java
+++ b/src/main/java/com/arpnetworking/commons/math/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.arpnetworking.commons.math;
+
+import com.arpnetworking.commons.javax.annotation.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/java/com/arpnetworking/commons/math/AccumulatorTest.java
+++ b/src/test/java/com/arpnetworking/commons/math/AccumulatorTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.commons.math;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the {@link Accumulator} implementations.
+ *
+ * @author Ville Koskela (ville at koskilabs dot com)
+ */
+@RunWith(Parameterized.class)
+public final class AccumulatorTest {
+
+    private static final List<Double> RANDOM_VALUE_DATA_SET;
+    private static final List<Double> RANDOM_CANCEL_DATA_SET;
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccumulatorTest.class);
+
+    static {
+        // Random values data set
+        final List<Double> valueDataSet = new ArrayList<>();
+        final Random valueRandom = new Random(564564359);
+        final double max = 1.0e16;
+        final double min = -1.0e16;
+        for (int i = 0; i < 4000000; ++i) {
+            valueDataSet.add(valueRandom.nextDouble() * (max - min) + min);
+        }
+        RANDOM_VALUE_DATA_SET = Collections.unmodifiableList(valueDataSet);
+
+        // Random cancellations data set
+        final List<Double> cancelDataSet = new ArrayList<>();
+        final Random cancelRandom = new Random(1591215254);
+        for (int i = 0; i < 4000000; ++i) {
+            final int group = cancelRandom .nextInt(4);
+            switch (group) {
+                case 0:
+                    cancelDataSet.add(1.0);
+                    break;
+                case 1:
+                    cancelDataSet.add(1.0e16);
+                    break;
+                case 2:
+                    cancelDataSet.add(-1.0);
+                    break;
+                case 3:
+                    cancelDataSet.add(-1.0e16);
+                    break;
+                default:
+                    throw new IllegalStateException("This should never happen");
+            }
+        }
+        RANDOM_CANCEL_DATA_SET = Collections.unmodifiableList(cancelDataSet);
+    }
+
+    private final Supplier<Accumulator> _accumulatorSupplier;
+    private final double _differentMagnitudesMargin;
+    private final double _differentSignsMargin;
+    private final double _randomCancellationMargin;
+    private final double _randomValuesMargin;
+
+    public AccumulatorTest(
+            final Supplier<Accumulator> accumulatorSupplier,
+            final Double differentMagnitudesMargin,
+            final Double differentSignsMargin,
+            final Double randomCancellationMargin,
+            final Double randomValuesMargin) {
+        _accumulatorSupplier = accumulatorSupplier;
+        _differentMagnitudesMargin = differentMagnitudesMargin;
+        _differentSignsMargin = differentSignsMargin;
+        _randomCancellationMargin = randomCancellationMargin;
+        _randomValuesMargin = randomValuesMargin;
+    }
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        (Supplier<Accumulator>) NaiveAccumulator::new,
+                        1.0E10,     // magnitudes
+                        0.0001,     // signs
+                        1.1e3,      // random cancel
+                        3.9e6},     // random values
+                new Object[]{
+                        (Supplier<Accumulator>) BigDecimalAccumulator::new,
+                        0.0001,     // magnitudes
+                        0.0001,     // signs
+                        0.0001,     // random cancel
+                        0.0001},    // random values
+                new Object[]{
+                        (Supplier<Accumulator>) KahanAccumulator::new,
+                        0.0001,     // magnitudes
+                        0.0001,     // signs
+                        0.0001,     // random cancel
+                        0.5e4},     // random values
+                new Object[]{
+                        (Supplier<Accumulator>) NeumaierAccumulator::new,
+                        0.0001,     // magnitudes
+                        0.0001,     // signs
+                        0.0001,     // random cancel
+                        0.0001},    // random values
+                new Object[]{
+                        (Supplier<Accumulator>) PairwiseAccumulator::new,
+                        8.0e9,      // magnitudes
+                        3.0e16,     // signs
+                        1.1e3,      // random cancel
+                        2.0e4});    // random values
+    }
+
+    @Test
+    public void testDifferentMagnitudes() {
+        final Accumulator accumulator = _accumulatorSupplier.get();
+        accumulator.accumulate(1.0e16);
+        for (int i = 0; i < 1000000; ++i) {
+            accumulator.accumulate(1.0);
+        }
+        assertEquals(1.0000000001E16, accumulator.getSum(), _differentMagnitudesMargin);
+    }
+
+    @Test
+    public void testDifferentSigns() {
+        final Accumulator accumulator = _accumulatorSupplier.get();
+        for (int i = 0; i < 4000000; ++i) {
+            final int group = i % 4;
+            switch (group) {
+                case 0:
+                    accumulator.accumulate(1.0);
+                    break;
+                case 1:
+                    accumulator.accumulate(1.0e16);
+                    break;
+                case 2:
+                    accumulator.accumulate(-1.0);
+                    break;
+                case 3:
+                    accumulator.accumulate(-1.0e16);
+                    break;
+                default:
+                    throw new IllegalStateException("This should never happen");
+            }
+        }
+        assertEquals(0.0, accumulator.getSum(), _differentSignsMargin);
+    }
+
+    @Test
+    public void testRandomValues() {
+        final Accumulator accumulator = _accumulatorSupplier.get();
+        for (final double value : RANDOM_VALUE_DATA_SET) {
+            accumulator.accumulate(value);
+        }
+
+        // The actual value is below and is approximately 3.32e18; all the
+        // algorithms did surprising well including Naive which did better than
+        // Pairwise. Other accumulator sums are:
+        //
+        // Naive:  -2.7135163974452634E18
+        // BigDe:  -2.7135163974456428E18
+        // Kahan:  -2.7135163974456433E18
+        // Neuma:  -2.7135163974456428E18
+        // Pairw:  -2.7135163974456448E18
+
+        LOGGER.info("Accumulator {} sum was: {}", accumulator.getClass().getSimpleName(), accumulator.getSum());
+
+        assertEquals(-2.7135163974456428E18, accumulator.getSum(), _randomValuesMargin);
+    }
+
+    @Test
+    public void testRandomCancellation() {
+        final Accumulator accumulator = _accumulatorSupplier.get();
+        for (final double value : RANDOM_CANCEL_DATA_SET) {
+            accumulator.accumulate(value);
+        }
+
+        // The actual value is below and is approximately 3.31e18; all the
+        // algorithms did surprising well including Naive which did better than
+        // Pairwise. Other accumulator sums are:
+        //
+        // Naive:  3310000000000000000.000000
+        // BigDe:  3310000000000001000.000000
+        // Kahan:  3310000000000001000.000000
+        // Neuma:  3310000000000001000.000000
+        // Pairw:  3310000000000000000.000000
+
+        LOGGER.info("Accumulator {} sum was: {}", accumulator.getClass().getSimpleName(), accumulator.getSum());
+
+        assertEquals(3310000000000001000.000000, accumulator.getSum(), _randomCancellationMargin);
+    }
+}

--- a/src/test/java/com/arpnetworking/commons/math/package-info.java
+++ b/src/test/java/com/arpnetworking/commons/math/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Ville Koskela
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.arpnetworking.commons.math;
+
+import com.arpnetworking.commons.javax.annotation.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/java/com/arpnetworking/commons/performance/BaseAccumulatorTestPerf.java
+++ b/src/test/java/com/arpnetworking/commons/performance/BaseAccumulatorTestPerf.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.commons.performance;
+
+import com.arpnetworking.commons.math.Accumulator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Base performance tests for the {@link Accumulator} implementations.
+ *
+ * @author Ville Koskela (ville at inscopemetrics dot io)
+ */
+public abstract class BaseAccumulatorTestPerf {
+
+    private static final List<Double> RANDOM_VALUE_DATA_SET;
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseAccumulatorTestPerf.class);
+
+    static {
+        // Random values data set
+        final List<Double> valueDataSet = new ArrayList<>();
+        final Random valueRandom = new Random(564564359);
+        final double max = 1.0e16;
+        final double min = -1.0e16;
+        for (int i = 0; i < 4000000; ++i) {
+            valueDataSet.add(valueRandom.nextDouble() * (max - min) + min);
+        }
+        RANDOM_VALUE_DATA_SET = Collections.unmodifiableList(valueDataSet);
+    }
+
+    protected void runTest(final Accumulator accumulator) {
+        for (final double value : RANDOM_VALUE_DATA_SET) {
+            accumulator.accumulate(value);
+        }
+
+        LOGGER.info("Accumulator {} sum was: {}", accumulator.getClass().getSimpleName(), accumulator.getSum());
+    }
+}

--- a/src/test/java/com/arpnetworking/commons/performance/BigDecimalAccumulatorTestPerf.java
+++ b/src/test/java/com/arpnetworking/commons/performance/BigDecimalAccumulatorTestPerf.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.performance;
+
+import com.arpnetworking.commons.math.BigDecimalAccumulator;
+import com.arpnetworking.test.junitbenchmarks.JsonBenchmarkConsumer;
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+/**
+ * Performance test for {@link BigDecimalAccumulator}.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+@BenchmarkOptions(callgc = true, benchmarkRounds = 10, warmupRounds = 5)
+public final class BigDecimalAccumulatorTestPerf extends BaseAccumulatorTestPerf {
+
+    private static final JsonBenchmarkConsumer JSON_BENCHMARK_CONSUMER = new JsonBenchmarkConsumer(
+            Paths.get("target/perf/bigdecimal-accumulator-performance-test.json"));
+    @Rule
+    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public final TestRule _benchMarkRule = new BenchmarkRule(JSON_BENCHMARK_CONSUMER);
+
+    @BeforeClass
+    public static void setUp() {
+        JSON_BENCHMARK_CONSUMER.prepareClass();
+    }
+
+    @Test
+    public void serializeSize() throws IOException {
+        runTest(new BigDecimalAccumulator());
+    }
+}

--- a/src/test/java/com/arpnetworking/commons/performance/KahanAccumulatorTestPerf.java
+++ b/src/test/java/com/arpnetworking/commons/performance/KahanAccumulatorTestPerf.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.performance;
+
+import com.arpnetworking.commons.math.KahanAccumulator;
+import com.arpnetworking.test.junitbenchmarks.JsonBenchmarkConsumer;
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+/**
+ * Performance test for {@link KahanAccumulator}.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+@BenchmarkOptions(callgc = true, benchmarkRounds = 10, warmupRounds = 5)
+public final class KahanAccumulatorTestPerf extends BaseAccumulatorTestPerf {
+
+    private static final JsonBenchmarkConsumer JSON_BENCHMARK_CONSUMER = new JsonBenchmarkConsumer(
+            Paths.get("target/perf/kahan-accumulator-performance-test.json"));
+    @Rule
+    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public final TestRule _benchMarkRule = new BenchmarkRule(JSON_BENCHMARK_CONSUMER);
+
+    @BeforeClass
+    public static void setUp() {
+        JSON_BENCHMARK_CONSUMER.prepareClass();
+    }
+
+    @Test
+    public void serializeSize() throws IOException {
+        runTest(new KahanAccumulator());
+    }
+}

--- a/src/test/java/com/arpnetworking/commons/performance/NaiveAccumulatorTestPerf.java
+++ b/src/test/java/com/arpnetworking/commons/performance/NaiveAccumulatorTestPerf.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.performance;
+
+import com.arpnetworking.commons.math.NaiveAccumulator;
+import com.arpnetworking.test.junitbenchmarks.JsonBenchmarkConsumer;
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+/**
+ * Performance test for {@link NaiveAccumulator}.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+@BenchmarkOptions(callgc = true, benchmarkRounds = 10, warmupRounds = 5)
+public final class NaiveAccumulatorTestPerf extends BaseAccumulatorTestPerf {
+
+    private static final JsonBenchmarkConsumer JSON_BENCHMARK_CONSUMER = new JsonBenchmarkConsumer(
+            Paths.get("target/perf/naive-accumulator-performance-test.json"));
+    @Rule
+    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public final TestRule _benchMarkRule = new BenchmarkRule(JSON_BENCHMARK_CONSUMER);
+
+    @BeforeClass
+    public static void setUp() {
+        JSON_BENCHMARK_CONSUMER.prepareClass();
+    }
+
+    @Test
+    public void serializeSize() throws IOException {
+        runTest(new NaiveAccumulator());
+    }
+}

--- a/src/test/java/com/arpnetworking/commons/performance/NeumaierAccumulatorTestPerf.java
+++ b/src/test/java/com/arpnetworking/commons/performance/NeumaierAccumulatorTestPerf.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.performance;
+
+import com.arpnetworking.commons.math.NeumaierAccumulator;
+import com.arpnetworking.test.junitbenchmarks.JsonBenchmarkConsumer;
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+/**
+ * Performance test for {@link NeumaierAccumulator}.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+@BenchmarkOptions(callgc = true, benchmarkRounds = 10, warmupRounds = 5)
+public final class NeumaierAccumulatorTestPerf extends BaseAccumulatorTestPerf {
+
+    private static final JsonBenchmarkConsumer JSON_BENCHMARK_CONSUMER = new JsonBenchmarkConsumer(
+            Paths.get("target/perf/neumaier-accumulator-performance-test.json"));
+    @Rule
+    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public final TestRule _benchMarkRule = new BenchmarkRule(JSON_BENCHMARK_CONSUMER);
+
+    @BeforeClass
+    public static void setUp() {
+        JSON_BENCHMARK_CONSUMER.prepareClass();
+    }
+
+    @Test
+    public void serializeSize() throws IOException {
+        runTest(new NeumaierAccumulator());
+    }
+}

--- a/src/test/java/com/arpnetworking/commons/performance/PairwiseAccumulatorTestPerf.java
+++ b/src/test/java/com/arpnetworking/commons/performance/PairwiseAccumulatorTestPerf.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.performance;
+
+import com.arpnetworking.commons.math.PairwiseAccumulator;
+import com.arpnetworking.test.junitbenchmarks.JsonBenchmarkConsumer;
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+/**
+ * Performance test for {@link PairwiseAccumulator}.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+@BenchmarkOptions(callgc = true, benchmarkRounds = 10, warmupRounds = 5)
+public final class PairwiseAccumulatorTestPerf extends BaseAccumulatorTestPerf {
+
+    private static final JsonBenchmarkConsumer JSON_BENCHMARK_CONSUMER = new JsonBenchmarkConsumer(
+            Paths.get("target/perf/pairwise-accumulator-performance-test.json"));
+    @Rule
+    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public final TestRule _benchMarkRule = new BenchmarkRule(JSON_BENCHMARK_CONSUMER);
+
+    @BeforeClass
+    public static void setUp() {
+        JSON_BENCHMARK_CONSUMER.prepareClass();
+    }
+
+    @Test
+    public void serializeSize() throws IOException {
+        runTest(new PairwiseAccumulator());
+    }
+}

--- a/src/test/java/com/arpnetworking/commons/performance/package-info.java
+++ b/src/test/java/com/arpnetworking/commons/performance/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.arpnetworking.commons.performance;
+
+import com.arpnetworking.commons.javax.annotation.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/resources/logback-perf.xml
+++ b/src/test/resources/logback-perf.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Dropbox
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<configuration>
+  <!-- IMPORTANT: This logger is only used during performance testing -->
+  <appender name="perf-logger" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>logs/performance-test.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>logs/performance-test.%d{yyyyMMdd-HH}.log.gz</fileNamePattern>
+      <maxHistory>20</maxHistory>
+    </rollingPolicy>
+    <encoder immediateFlush="false">
+      <pattern>%relative %date %t [%level] %logger : %message %ex%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="perf-async" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="perf-logger"/>
+    <discardingThreshold>0</discardingThreshold>
+  </appender>
+
+  <logger name="com.arpnetworking.commons.performance" level="DEBUG" />
+  <logger name="com.arpnetworking.test.junitbenchmarks" level="INFO" />
+
+  <root level="WARN">
+    <appender-ref ref="perf-async"/>
+  </root>
+</configuration>


### PR DESCRIPTION
Implementations:

* Naive - Use built-in double arithmetic. Unbounded error.
* BigDecimal - Use built-in `BigDecimal` class. Zero error.
* Kahan - O(1) error. See: https://en.wikipedia.org/wiki/Kahan_summation_algorithm
* Neumaier - Variant of Kahan. O(1) error.
* Pairwise - O(LOG N) error. See: https://en.wikipedia.org/wiki/Pairwise_summation

Error:

Expected value: -2.7135163974456428E18

Actual values:
```
Naive:  -2.7135163974452634E18
BigDe:  -2.7135163974456428E18
Kahan:  -2.7135163974456433E18
Neuma:  -2.7135163974456428E18
Pairw:  -2.7135163974456448E18
```

Errors:
```
Naive:  3.9e6 (worst)
BigDe:  0.0 (best)
Kahan:  0.5e4
Neuma:  0.0 (best)
Pairw:  2.0e4
```

Performance Test Results:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.arpnetworking.commons.performance.BigDecimalAccumulatorTestPerf
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[WARNING] Corrupted stdin stream in forked JVM 1. See the dump file /Users/ville/Workspace/ArpNetworking/commons/target/surefire-reports/2020-06-05T00-02-48_070-jvmRun1.dumpstream
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.744 s - in com.arpnetworking.commons.performance.BigDecimalAccumulatorTestPerf
[INFO] Running com.arpnetworking.commons.performance.NaiveAccumulatorTestPerf
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[WARNING] Corrupted stdin stream in forked JVM 1. See the dump file /Users/ville/Workspace/ArpNetworking/commons/target/surefire-reports/2020-06-05T00-02-48_070-jvmRun1.dumpstream
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.821 s - in com.arpnetworking.commons.performance.NaiveAccumulatorTestPerf
[INFO] Running com.arpnetworking.commons.performance.KahanAccumulatorTestPerf
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[WARNING] Corrupted stdin stream in forked JVM 1. See the dump file /Users/ville/Workspace/ArpNetworking/commons/target/surefire-reports/2020-06-05T00-02-48_070-jvmRun1.dumpstream
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 24.895 s - in com.arpnetworking.commons.performance.KahanAccumulatorTestPerf
[INFO] Running com.arpnetworking.commons.performance.PairwiseAccumulatorTestPerf
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[WARNING] Corrupted stdin stream in forked JVM 1. See the dump file /Users/ville/Workspace/ArpNetworking/commons/target/surefire-reports/2020-06-05T00-02-48_070-jvmRun1.dumpstream
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 27.701 s - in com.arpnetworking.commons.performance.PairwiseAccumulatorTestPerf
[INFO] Running com.arpnetworking.commons.performance.NeumaierAccumulatorTestPerf
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[WARNING] Corrupted stdin stream in forked JVM 1. See the dump file /Users/ville/Workspace/ArpNetworking/commons/target/surefire-reports/2020-06-05T00-02-48_070-jvmRun1.dumpstream
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.305 s - in com.arpnetworking.commons.performance.NeumaierAccumulatorTestPerf
```

BigDecimal:
      "avg" : 0.3476,
      "stddev" : 0.0029393876913372395

Kahan:
      "avg" : 0.0334,
      "stddev" : 0.0015620499351813484

Naive:
      "avg" : 0.030600000000000002,
      "stddev" : 0.0014282856857085176

Neumaier:
      "avg" : 0.0344,
      "stddev" : 0.0029051678092667996

Pairwise:
      "avg" : 0.0896,
      "stddev" : 0.0019595917942268116